### PR TITLE
Update php version to allow for 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "magento-module",
     "license": "MIT",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0",
+        "php": "~5.5.0|~5.6.0|~7.0",
         "sitewards/setup": "1.0.0"
     },
     "autoload": {


### PR DESCRIPTION
Allow for PHP 7.1. A question here is should we also still allow 5.5?